### PR TITLE
Update `TimberFrameBarn` template (was `sollingladen`) 

### DIFF
--- a/assets/prefabs/structures/TimberFrameBarn.prefab
+++ b/assets/prefabs/structures/TimberFrameBarn.prefab
@@ -93,119 +93,119 @@
         "region": { "min": [-6, 3, 0], "size": [6, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.FRONT",
         "region": { "min": [-6, 1, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.LEFT",
         "region": { "min": [-5, 2, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.BACK",
         "region": { "min": [-2, 2, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.RIGHT",
         "region": { "min": [-1, 1, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.RIGHT",
         "region": { "min": [-6, 2, -16], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.FRONT",
         "region": { "min": [-1, 2, -16], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.BACK",
         "region": { "min": [-6, 2, -1], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.LEFT",
         "region": { "min": [-1, 2, -1], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.LEFT",
         "region": { "min": [-6, 1, 0], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.FRONT",
         "region": { "min": [-5, 2, 0], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.RIGHT",
         "region": { "min": [-2, 2, 0], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "blockType": "StructuralResources:TimberFrameDiagonal.BACK",
         "region": { "min": [-1, 1, 0], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.RIGHT",
         "region": { "min": [-6, 2, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.FRONT",
         "region": { "min": [-5, 1, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.BACK",
         "region": { "min": [-2, 1, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.LEFT",
         "region": { "min": [-1, 2, -17], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.FRONT",
         "region": { "min": [-6, 1, -16], "size": [1, 1, 16] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.LEFT",
         "region": { "min": [-1, 1, -16], "size": [1, 1, 16] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.RIGHT",
         "region": { "min": [-6, 2, 0], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.FRONT",
         "region": { "min": [-5, 1, 0], "size": [4, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFrameVertical",
+        "blockType": "StructuralResources:TimberFrameVertical.LEFT",
         "region": { "min": [-1, 2, 0], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.RIGHT",
         "region": { "min": [-6, 2, -13], "size": [1, 1, 2] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.LEFT",
         "region": { "min": [-1, 2, -13], "size": [1, 1, 2] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.RIGHT",
         "region": { "min": [-6, 2, -9], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.LEFT",
         "region": { "min": [-1, 2, -9], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.RIGHT",
         "region": { "min": [-6, 2, -6], "size": [1, 1, 2] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.LEFT",
         "region": { "min": [-1, 2, -6], "size": [1, 1, 2] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.RIGHT",
         "region": { "min": [-6, 2, -2], "size": [1, 1, 1] }
       },
       {
-        "blockType": "StructuralResources:TimberFramePlain",
+        "blockType": "StructuralResources:TimberFramePlain.LEFT",
         "region": { "min": [-1, 2, -2], "size": [1, 1, 1] }
       },
       {

--- a/assets/prefabs/structures/TimberFrameBarn.prefab
+++ b/assets/prefabs/structures/TimberFrameBarn.prefab
@@ -1,0 +1,305 @@
+{
+  "StructureTemplate": {
+    "animationType": "NoAnimation"
+  },
+  "SpawnBlockRegions": {
+    "regionsToFill": [
+      {
+        "blockType": "CoreBlocks:DoorBottom.BACK",
+        "region": { "min": [-4, 1, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorBottom.BACK",
+        "region": { "min": [-3, 1, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.BACK",
+        "region": { "min": [-4, 2, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.FRONT",
+        "region": { "min": [-4, 2, 0], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.BACK",
+        "region": { "min": [-3, 2, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.LEFT",
+        "region": { "min": [-1, 2, -15], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.LEFT",
+        "region": { "min": [-1, 2, -11], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.LEFT",
+        "region": { "min": [-1, 2, -8], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.LEFT",
+        "region": { "min": [-1, 2, -4], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.RIGHT",
+        "region": { "min": [-6, 2, -15], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.RIGHT",
+        "region": { "min": [-6, 2, -11], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.RIGHT",
+        "region": { "min": [-6, 2, -8], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:DoorTop.RIGHT",
+        "region": { "min": [-6, 2, -4], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-6, 3, -17], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-6, 3, -16], "size": [1, 1, 16] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-5, 4, -16], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-1, 3, -16], "size": [1, 1, 16] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-5, 4, -15], "size": [1, 1, 13] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-4, 5, -15], "size": [2, 1, 14] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-2, 4, -15], "size": [1, 1, 14] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-4, 4, -1], "size": [3, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber",
+        "region": { "min": [-6, 3, 0], "size": [6, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-6, 1, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-5, 2, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-2, 2, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-1, 1, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-6, 2, -16], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-1, 2, -16], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-6, 2, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-1, 2, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-6, 1, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-5, 2, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-2, 2, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameDiagonal",
+        "region": { "min": [-1, 1, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-6, 2, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-5, 1, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-2, 1, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-1, 2, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-6, 1, -16], "size": [1, 1, 16] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-1, 1, -16], "size": [1, 1, 16] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-6, 2, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-5, 1, 0], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFrameVertical",
+        "region": { "min": [-1, 2, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-6, 2, -13], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-1, 2, -13], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-6, 2, -9], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-1, 2, -9], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-6, 2, -6], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-1, 2, -6], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-6, 2, -2], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:TimberFramePlain",
+        "region": { "min": [-1, 2, -2], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.BACK",
+        "region": { "min": [-5, 5, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.BACK",
+        "region": { "min": [-6, 4, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.FRONT",
+        "region": { "min": [-1, 4, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.FRONT",
+        "region": { "min": [-2, 5, -16], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.LEFT",
+        "region": { "min": [-6, 4, -17], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.LEFT",
+        "region": { "min": [-5, 5, -16], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.RIGHT",
+        "region": { "min": [-2, 5, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:SlopeCorner.RIGHT",
+        "region": { "min": [-1, 4, 0], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.BACK",
+        "region": { "min": [-4, 5, -1], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.BACK",
+        "region": { "min": [-5, 4, 0], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.FRONT",
+        "region": { "min": [-5, 4, -17], "size": [4, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.FRONT",
+        "region": { "min": [-4, 5, -16], "size": [2, 1, 1] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.LEFT",
+        "region": { "min": [-6, 4, -16], "size": [1, 1, 16] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.LEFT",
+        "region": { "min": [-5, 5, -15], "size": [1, 1, 14] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.RIGHT",
+        "region": { "min": [-1, 4, -16], "size": [1, 1, 16] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.RIGHT",
+        "region": { "min": [-2, 5, -15], "size": [1, 1, 14] }
+      },
+      {
+        "blockType": "StructuralResources:RoofTilesSmallTimber:engine:slope.RIGHT",
+        "region": { "min": [-5, 4, -2], "size": [1, 1, 2] }
+      },
+      {
+        "blockType": "CoreBlocks:Torch.BACK",
+        "region": { "min": [-5, 2, -16], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:Torch.BACK",
+        "region": { "min": [-2, 2, -16], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:Torch.FRONT",
+        "region": { "min": [-5, 2, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:Torch.FRONT",
+        "region": { "min": [-2, 2, -1], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:Torch.LEFT",
+        "region": { "min": [-2, 2, -9], "size": [1, 1, 1] }
+      },
+      {
+        "blockType": "CoreBlocks:Torch.RIGHT",
+        "region": { "min": [-5, 2, -9], "size": [1, 1, 1] }
+      }
+    ]
+  }
+}

--- a/module.txt
+++ b/module.txt
@@ -7,7 +7,8 @@
     "dependencies": [
         {"id": "CoreAssets", "minVersion": "1.0.0"},
         {"id": "CoreBlocks", "minVersion": "1.0.0"},
-        {"id": "StructureTemplates", "minVersion": "0.3.0"}
+        {"id": "StructureTemplates", "minVersion": "0.3.0"},
+        {"id": "StructuralResources", "minVersion": "2.0.0"}
     ],
     "serverSideOnly": false
 }


### PR DESCRIPTION
Updates the templates to use blocks from StructuralResources (as preparation to move the templates to a different repository, too).